### PR TITLE
Enhanced 'R/r' Handling in Text Replacement

### DIFF
--- a/OwoSpeak.lua
+++ b/OwoSpeak.lua
@@ -72,10 +72,28 @@ function SendChatMessage(msg, chatType, ...)
 		local whatsthis = random(10)
 		-- tempowawiwy wepwace winks wif owos
 		local s = msg:gsub("|c.-|r", ReplaceLink)
-		-- wepwace waid mawkews
+		-- wepwace waid mawkers
+		-- pwacehowders
 		s = s:gsub("{.-}", ReplaceLink)
-		s = s:gsub("[LR]", "W")
-		s = s:gsub("[lr]", "w")
+		s = s:gsub("([lr])([%S]*s?)", function(l, following)
+		    if l == 'r' and following == 's' then
+		        return 'r' .. following
+		    elseif l == 'R' and following == 's' then
+		        return 'R' .. following
+		    else
+		        return 'w' .. following
+		    end
+		end)
+		
+		s = s:gsub("([LR])([%S]*S?)", function(L, following)
+		    if L == 'R' and following == 'S' then
+		        return 'R' .. following
+		    elseif L == 'L' then
+		        return 'W' .. following
+		    else
+		        return 'W' .. following
+		    end
+		end)
 		if whatsthis <= 5 then
 			s = s:gsub("U([^VW])", "UW%1")
 			s = s:gsub("u([^vw])", "uw%1")


### PR DESCRIPTION
This PR updates the text replacement logic to ensure that 'r' or 'R' is not replaced when it is the last character in a word or is followed by an 's'.

This preserves the natural pronunciation of certain words. By keeping 'r' and 'R' unchanged when they are at the end of words or followed by 's', we ensure words like "markers" are transformed to "mawkers" instead of "mawkews". The original replacement often distorted the sound, making words less recognizable. 

This change keeps the playful 'UwU' style while ensuring words still sound closer to their original form.

Tested in-game by editing my addon's code.

The update will not affect the addon's performance or other features.
